### PR TITLE
Format cmd will now only find package.json path if it is required

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,14 @@ function startWatching({ watch, match, exec }, options) {
           return log(`${prefix}: skipping ${relativeFilepath}`);
         }
 
-        formatCmd(cmd, filepath).then(cmd => {
-          log(`${prefix}: ${cmd}`);
-          spawn(cmd, [], { shell: true, stdio: 'inherit' });
-        });
+        formatCmd(cmd, filepath)
+          .then(cmd => {
+            log(`${prefix}: ${cmd}`);
+            spawn(cmd, [], { shell: true, stdio: 'inherit' });
+          })
+          .catch(error => {
+            console.error(error)
+          });
       });
     });
   })


### PR DESCRIPTION
The reason for this PR is because I have found this tool useful for projects outside of JS, where I would not have a package.json file anywhere in the tree. Using the current version (2.1.0) for this task would cause a silent failure as dirname on line 23 of format-cmd.js would be given `null`. To remedy this I have added a catch to report any errors which may occur to give the user a little more idea about what is going on.

I have also added a package.json path resolver which will skip the lookup if it's not even required by the command. It will also throw an Error where a path is required but none can be found to make it clearer to the user why the command isn't being executed.

Let me know what you think!